### PR TITLE
Avoid printing the error message

### DIFF
--- a/lib/gengo-ruby/gengo_exception.rb
+++ b/lib/gengo-ruby/gengo_exception.rb
@@ -8,8 +8,6 @@ module Gengo
       @opstat = opstat
       @code = code
       @msg = msg
-
-      puts msg
     end
   end
 end


### PR DESCRIPTION
There's no need to print the error message here and it doesn't play well when raising a Gengo::Exception in unit tests. It outputs the exception message in the logs.
