### PR TITLE
Force encoding to prevent "Alexander Lidé" error.

### DIFF
--- a/gengo-ruby.gemspec
+++ b/gengo-ruby.gemspec
@@ -1,4 +1,4 @@
- # encoding: UTF-8
+# encoding: UTF-8
 Gem::Specification.new do |gs|
     gs.name = "gengo"
     gs.version = "0.0.5"


### PR DESCRIPTION
Older versions of ruby have issues bundling this gem due to character encoding of Alexander Lidé's name.  This should resolve that problem.
