### PR TITLE
Allow truthy values for sandbox option

### DIFF
--- a/lib/gengo-ruby/api_handler.rb
+++ b/lib/gengo-ruby/api_handler.rb
@@ -36,7 +36,7 @@ module Gengo
 
       # Let's go ahead and separate these out, for clarity...
       @debug = @opts[:debug]
-      @api_host = (@opts[:sandbox] == true ? Gengo::Config::SANDBOX_API_HOST : Gengo::Config::API_HOST)
+      @api_host = (@opts[:sandbox] ? Gengo::Config::SANDBOX_API_HOST : Gengo::Config::API_HOST)
 
       # More of a public "check this" kind of object.
       @client_info = {"VERSION" => Gengo::Config::VERSION}


### PR DESCRIPTION
it's useful when setting option via environment variable.

```sh
export GENGO_USE_SANDBOX=t
```

```ruby
gengo = Gengo::API.new(
  public_key:  ENV['GENGO_PUBLIC_KEY'],
  private_key: ENV['GENGO_PRIVATE_KEY'],
  sandbox:     ENV['GENGO_USE_SANDBOX'],
)
```