### PR TITLE
[WIP]add version to mime-types

### DIFF
--- a/gengo-ruby.gemspec
+++ b/gengo-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gs|
 
     gs.add_dependency('json')
     gs.add_dependency('multipart-post')
-    gs.add_dependency('mime-types')
+    gs.add_dependency('mime-types', '< 2.99')
     gs.add_development_dependency 'rspec', '~> 2.7'
     gs.add_development_dependency 'rack-test'
     gs.add_development_dependency 'rake'


### PR DESCRIPTION
The latest `mime-types` only supports ruby `>=2.0` and you can't install gengo library if you use ruby 1.9.X.
https://rubygems.org/gems/mime-types/versions/3.0
But I'm not sure this is the way to go, maybe gengo also can support only ruby `>=2.0` ?  If so, I'll just close this PR.

Investigating the dependency issue happens on travis test.